### PR TITLE
Fixed capitalisation on #include statements

### DIFF
--- a/NTP/ntp.cpp
+++ b/NTP/ntp.cpp
@@ -9,7 +9,7 @@
  *****************************************************************************/
 
 #include "ESP8266WiFi.h"
-#include "arduino.h"
+#include "Arduino.h"
 #include "ntp.h"
 
 NTP::NTP(void)

--- a/NTP/ntp.h
+++ b/NTP/ntp.h
@@ -12,7 +12,7 @@
 #include "IPAddress.h"
 #include "WiFiUdp.h"
 #include <stdint.h>
-#include <time.h>
+#include <Time.h>
 
 
 class NTP

--- a/tm1637/TM1637.cpp
+++ b/tm1637/TM1637.cpp
@@ -1,6 +1,6 @@
 
 #include "TM1637.h"
-#include "arduino.h"
+#include "Arduino.h"
 
 tm1637::tm1637(uint8_t ClockPin, uint8_t DataPin)
 {


### PR DESCRIPTION
Nice example, but to get it running I had to fix some capitalisation issues on your includes. I guess you must be running on a case insensitive OS?

Thanks for sharing!
